### PR TITLE
Fix some CocoaPods related settings in Xcode (#239)

### DIFF
--- a/Example/ios/ios.xcodeproj/project.pbxproj
+++ b/Example/ios/ios.xcodeproj/project.pbxproj
@@ -261,7 +261,6 @@
 				CD93EC8817E76E290062BE20 /* Frameworks */,
 				CD93EC8917E76E290062BE20 /* Resources */,
 				01A5049A4137D2B0AC2675EF /* [CP] Embed Pods Frameworks */,
-				CFD8060A28B5CB0CDA3FF3F0 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -386,21 +385,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "echo \"Remove tmp directory\"\ncd /tmp\nrm -rf PiwikTracker\n\necho \"Clone documentation branch\"\ngit clone -b gh-pages https://github.com/piwik/piwik-sdk-ios.git\n\necho \"Copy new documentation into place\"\ncd piwik-sdk-ios\nrm -rf docs\ncp -rv \"$SOURCE_ROOT\"/Doc docs\n\necho \"Commit changes\"\ngit commit -am \"Update API documentation\"\n\necho \"Push changes\"\ngit push origin gh-pages";
-		};
-		CFD8060A28B5CB0CDA3FF3F0 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/../../Pods/Target Support Files/Pods-example-ios/Pods-example-ios-resources.sh\"\n";
-			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -546,7 +530,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = AC92312231977BC13ABD15F1 /* Pods-example-ios.debug.xcconfig */;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited)";
 				CLANG_ENABLE_MODULES = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
@@ -568,7 +552,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = A512D280229592361DDA7E8D /* Pods-example-ios.release.xcconfig */;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited)";
 				CLANG_ENABLE_MODULES = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;

--- a/Example/macos/macos.xcodeproj/project.pbxproj
+++ b/Example/macos/macos.xcodeproj/project.pbxproj
@@ -100,7 +100,6 @@
 				1F88018F1EBFBBCC00707352 /* Frameworks */,
 				1F8801901EBFBBCC00707352 /* Resources */,
 				50DAC7215CB8D45774949E1F /* [CP] Embed Pods Frameworks */,
-				7B79F133D2446A6E12DC7AA0 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -193,21 +192,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${SRCROOT}/../../Pods/Target Support Files/Pods-example-macos/Pods-example-macos-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		7B79F133D2446A6E12DC7AA0 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/../../Pods/Target Support Files/Pods-example-macos/Pods-example-macos-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */

--- a/Example/tvos/tvos.xcodeproj/project.pbxproj
+++ b/Example/tvos/tvos.xcodeproj/project.pbxproj
@@ -100,7 +100,6 @@
 				1F38EBE21EE55AE50021FBF8 /* Frameworks */,
 				1F38EBE31EE55AE50021FBF8 /* Resources */,
 				1BAD3F74505E36F2DCCEFA9D /* [CP] Embed Pods Frameworks */,
-				38DBD44A2E80CAA046528641 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -174,21 +173,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${SRCROOT}/../../Pods/Target Support Files/Pods-example-tvos/Pods-example-tvos-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		38DBD44A2E80CAA046528641 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/../../Pods/Target Support Files/Pods-example-tvos/Pods-example-tvos-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		A7D0D37AD3004C01CA94CC9D /* [CP] Check Pods Manifest.lock */ = {

--- a/MatomoTracker.xcodeproj/project.pbxproj
+++ b/MatomoTracker.xcodeproj/project.pbxproj
@@ -256,7 +256,6 @@
 				1FCA6D411DBE0B2F0033F01C /* Frameworks */,
 				1FCA6D421DBE0B2F0033F01C /* Resources */,
 				22AB6DF399C52F3B2B8ED25F /* [CP] Embed Pods Frameworks */,
-				F440219733D7385F192471AC /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -362,21 +361,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		F440219733D7385F192471AC /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-MatomoTrackerTests/Pods-MatomoTrackerTests-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -593,7 +577,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = ECADEAA1E653EE3DA30A1FDC /* Pods-MatomoTrackerTests.debug.xcconfig */;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited)";
 				CLANG_ENABLE_MODULES = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
@@ -613,7 +597,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 2FD38CC515C49A9A8922407D /* Pods-MatomoTrackerTests.release.xcconfig */;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited)";
 				CLANG_ENABLE_MODULES = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;

--- a/MatomoTracker.xcworkspace/contents.xcworkspacedata
+++ b/MatomoTracker.xcworkspace/contents.xcworkspacedata
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Workspace
    version = "1.0">
+   <FileRef
+      location = "group:MatomoTracker.xcodeproj">
+   </FileRef>
    <Group
       location = "container:"
       name = "Examples">
@@ -15,12 +18,6 @@
       </FileRef>
    </Group>
    <FileRef
-      location = "group:/Users/corneliushorstmann/Development/piwik-sdk-ios/MatomoTracker.xcodeproj">
-   </FileRef>
-   <FileRef
       location = "group:Pods/Pods.xcodeproj">
-   </FileRef>
-   <FileRef
-      location = "group:MatomoTracker.xcodeproj">
    </FileRef>
 </Workspace>

--- a/MatomoTracker.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/MatomoTracker.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
* removes dead, duplicate reference to MatomoTracker.xcodeproj

* fixes settings for iOS (example) and MatomoTrackerTests targets regarding ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES

setting was ‘YES’, CocoaPods suggests to use $(inherited) instead